### PR TITLE
Update CloudWatch alarm pinning to v0.12.6

### DIFF
--- a/modules/client/README.md
+++ b/modules/client/README.md
@@ -24,16 +24,39 @@ module "vpn1" {
 
 There should be no changes required to move from previous versions of this module to version 0.12.0 or higher.
 
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+| aws | >= 2.7.0 |
+
 ## Providers
 
 | Name | Version |
 |------|---------|
 | aws | >= 2.7.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| client_vpn_status | git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.6 |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/cloudwatch_log_group) |
+| [aws_cloudwatch_log_stream](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/cloudwatch_log_stream) |
+| [aws_ec2_client_vpn_endpoint](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/ec2_client_vpn_endpoint) |
+| [aws_ec2_client_vpn_network_association](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/ec2_client_vpn_network_association) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/security_group) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | alarm\_evaluations | The number of periods over which data is evaluated to monitor VPN connection status. | `number` | `10` | no |
 | alarm\_period | Time the specified statistic is applied. Must be in seconds that is also a multiple of 60. | `number` | `60` | no |
 | client\_vpn\_cidr\_block | Add the IPv4 address range, in CIDR notation, from which to assign client IP Address must be either /16 or /22 address space | `string` | n/a | yes |
@@ -56,4 +79,3 @@ There should be no changes required to move from previous versions of this modul
 |------|-------------|
 | aws\_ec2\_client\_vpn\_endpoint\_dns | client vpn end point DNS |
 | aws\_ec2\_client\_vpn\_endpoint\_id | client vpn end point id |
-

--- a/modules/client/main.tf
+++ b/modules/client/main.tf
@@ -77,7 +77,7 @@ resource "aws_ec2_client_vpn_endpoint" "client_vpn" {
 }
 
 module "client_vpn_status" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.4"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.6"
 
   alarm_description        = "${var.name}-VPN Connection State"
   alarm_name               = "${var.name}-VPN-Status"

--- a/modules/site/README.md
+++ b/modules/site/README.md
@@ -64,16 +64,39 @@ The following module variables were removed as they are no longer necessary:
 - `use_bgp_inside_cidrs`
 - `use_preshared_keys`
 
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+| aws | >= 2.7.0 |
+
 ## Providers
 
 | Name | Version |
 |------|---------|
 | aws | >= 2.7.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| vpn_status | git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.6 |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_customer_gateway](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/customer_gateway) |
+| [aws_vpn_connection](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/vpn_connection) |
+| [aws_vpn_connection_route](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/vpn_connection_route) |
+| [aws_vpn_gateway](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/vpn_gateway) |
+| [aws_vpn_gateway_route_propagation](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/vpn_gateway_route_propagation) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | alarm\_evaluations | The number of periods over which data is evaluated to monitor VPN connection status. | `number` | `10` | no |
 | alarm\_period | Time the specified statistic is applied. Must be in seconds that is also a multiple of 60. | `number` | `60` | no |
 | bgp\_asn | An existing ASN assigned to the remote network, or one of the private ASNs in the 64512 - 65534 range.  Exceptions: 7224 cannot be used in the us-east-1 region and 9059 cannot be used in eu-west-1 region. | `number` | `65000` | no |
@@ -102,4 +125,3 @@ The following module variables were removed as they are no longer necessary:
 |------|-------------|
 | customer\_gateway | Customer Gateway ID |
 | vpn\_gateway | VPN Gateway ID |
-

--- a/modules/site/main.tf
+++ b/modules/site/main.tf
@@ -163,7 +163,7 @@ resource "aws_vpn_gateway_route_propagation" "route_propagation" {
 }
 
 module "vpn_status" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.4"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.6"
 
   alarm_description        = "${var.name}-VPN Connection State"
   alarm_name               = "${var.name}-VPN-Status"


### PR DESCRIPTION
##### Corresponding Issue(s):
[MPCSUPENG-2116](https://jira.rax.io/browse/MPCSUPENG-2116)

##### Summary of change(s):
Updates pinning of CloudWatch alarm module to v0.12.6 to correct validation errors

##### Reason for Change(s):

- Corrects validation errors introduced due to recent AWS provider updates

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
Yes, updates to CW Alarm module
##### If input variables or output variables have changed or has been added, have you updated the README?
NA
##### Do examples need to be updated based on changes?
NA
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
